### PR TITLE
Do not crash if 404 page was not set

### DIFF
--- a/http/httpwebengine.cpp
+++ b/http/httpwebengine.cpp
@@ -37,7 +37,8 @@ namespace Http {
 
 WebEngine::WebEngine(QObject *parent) :
     QObject(parent),
-    Responder() {
+    Responder(),
+    _notFoundPage(Q_NULLPTR) {
 }
 
 void WebEngine::respond(QSslSocket* sslSocket) {
@@ -66,7 +67,13 @@ void WebEngine::respond(QSslSocket* sslSocket) {
             resource->deliver(httpRequest, httpResponse);
         } else {
             // Otherwise generate a 404.
-            _notFoundPage->deliver(httpRequest, httpResponse);
+            if (_notFoundPage) {
+                _notFoundPage->deliver(httpRequest, httpResponse);
+            } else {
+                // if the 404 page was not set, generate simple HTML response
+                httpResponse.setBody(QByteArray("<h1>404 Not found</h1>"));
+                httpResponse.setHeader(ContentType, "text/html");
+            }
             httpResponse.setStatusCode(NotFound);
         }
 


### PR DESCRIPTION
Pull #10  request from @neochapay has introduced a crash if page requested was not found and "NotFoundPage" was not set (null pointer dereference). So, 2 simple changes can fix it:
- explicitly initialize `_notFoundPage` to nullptr
- if `_notFoundPage` was not set, generate a dummy response

P.S. `else` branch with dummy response can be removed if you don't like it.