### PR TITLE
Fixed http resource route match, for example: /users/{id}.json

### DIFF
--- a/http/httpresource.cpp
+++ b/http/httpresource.cpp
@@ -40,8 +40,9 @@ Resource::Resource(QString uniqueIdentifier,
 bool Resource::match(QString uniqueIdentifier) {
     // Split both the unique identifier of this resource the one in question,
     // so we can compare those.
-    QStringList splittedReferenceUri = this->uniqueIdentifier().split("/", QString::SkipEmptyParts);
-    QStringList splittedRequestedUri = uniqueIdentifier.split("/", QString::SkipEmptyParts);
+    QRegExp separator("[(.|/)]");
+    QStringList splittedReferenceUri = this->uniqueIdentifier().split(separator, QString::SkipEmptyParts);
+    QStringList splittedRequestedUri = uniqueIdentifier.split(separator, QString::SkipEmptyParts);
 
     int count = splittedRequestedUri.count();
 
@@ -69,8 +70,9 @@ bool Resource::match(QString uniqueIdentifier) {
 QMap<QString, QString> Resource::uriParameters(QString uniqueIdentifier) {
     // Split both the unique identifier of this resource the one in question,
     // so we can compare those.
-    QStringList splittedReferenceUri = this->uniqueIdentifier().split("/", QString::SkipEmptyParts);
-    QStringList splittedRequestedUri = uniqueIdentifier.split("/", QString::SkipEmptyParts);
+    QRegExp separator("[(.|/)]");
+    QStringList splittedReferenceUri = this->uniqueIdentifier().split(separator, QString::SkipEmptyParts);
+    QStringList splittedRequestedUri = uniqueIdentifier.split(separator, QString::SkipEmptyParts);
 
     // Create a parameter map.
     QMap<QString, QString> uriParameterMap;

--- a/http/httpresource.h
+++ b/http/httpresource.h
@@ -73,6 +73,7 @@ public:
      * will match
      *  /service/user1/23
      *  /service/user4/29
+     * /service/users/{id}.json will match /service/users/{id}.json
      * @returns the unique resource identifier for this resource.
      */
     QString uniqueIdentifier();


### PR DESCRIPTION
Make http resource uniqueIdentifier work in some case, for example: /users/{id}.json